### PR TITLE
-ability to use custom template (parameter templatePath)

### DIFF
--- a/chart/base.js
+++ b/chart/base.js
@@ -413,8 +413,10 @@ var Chart = Backbone.Model.extend ({
 			function (cb) {
 				me.zip = new JSZip ();
 				me.setTemplateName ();
-				fs.readFile (__dirname + "/../template/" + me.tplName + ".xlsx", function (err, data) {
+				let path = me.templatePath ? me.templatePath : (__dirname + "/../template/" + me.tplName + ".xlsx");
+				fs.readFile(path, function (err, data) {
 					if (err) {
+						console.error(`Template ${path} not read: ${err}`);
 						return cb (err);
 					};
 					me.zip.load (data);


### PR DESCRIPTION
Ability to use custom templates outside of this module. Example:

`const path = require('path').dirname(require.main.filename);
const xl = require('xlsx-chart');

function xlsx(data) {
	const doc = new xl();
	var opts = {
		file: path + '/downloads/' + data.random,
		chart: "line",
		templatePath: path + '/templates/znamka.xlsx',
...`