### PR TITLE
- ability to disable line smoothing in chart

### DIFF
--- a/chart/base.js
+++ b/chart/base.js
@@ -267,7 +267,8 @@ var Chart = Backbone.Model.extend ({
 								})
 							}
 						}
-					}
+					},
+					"c:smooth": me.noSmoothLines ? 0 : undefined //disable line smoothing in chart
 				};
 				if (chart == "scatter") {
 					r ["c:xVal"] = r ["c:cat"];


### PR DESCRIPTION
Ability to disable line smoothing in chart. Only tested with line chart...

Example:
https://drive.google.com/file/d/1XK3AWMLD5lERa-Gps-Jhi0m9fHW712Za/view?usp=sharing
https://drive.google.com/file/d/1uAisIwLHipnlRcwEsncbNYRRi924H7cR/view?usp=sharing

Implemented because if there are values on the edge of a graph, smoothing causes line to be beyond visible area.